### PR TITLE
Fix footer copyright character

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,7 +16,7 @@ function App() {
 
       {/* Footer */}
       <footer className="bg-gray-100 text-center text-sm text-gray-600 py-4 mt-8 border-t">
-        s© {new Date().getFullYear()} eugeniop's Itinerarium Latinum. All rights reserved.
+        © {new Date().getFullYear()} eugeniop's Itinerarium Latinum. All rights reserved.
       </footer>
     </div>
   )


### PR DESCRIPTION
## Summary
- remove stray letter before copyright symbol in footer

## Testing
- `npm run build`
- `npx http-server dist -p 8080` *(started server to inspect built files)*

------
https://chatgpt.com/codex/tasks/task_e_6844d55289f48332b755c4dbad655abe