### PR TITLE
Add quiz support to posts

### DIFF
--- a/public/posts/quiz-basics.md
+++ b/public/posts/quiz-basics.md
@@ -1,0 +1,14 @@
+---
+questions:
+  - prompt: "Which languages evolved from Latin?"
+    options:
+      - "German and Dutch"
+      - "Italian, French, Spanish and Romanian"
+      - "Chinese and Japanese"
+    answer: 1
+  - prompt: "Is Latin considered a living language?"
+    options:
+      - "Yes"
+      - "No"
+    answer: 1
+---


### PR DESCRIPTION
## Summary
- render `PostPage` with Content/Quiz tabs
- load quiz data from `quiz-{slug}.md` files
- show multiple choice questions with Done and Reset buttons
- add example quiz for `basics` post

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6846344cc3708332ba7091e19841fcdb