### PR TITLE
Add multi-answer quiz support

### DIFF
--- a/public/posts/quiz-basics.md
+++ b/public/posts/quiz-basics.md
@@ -3,9 +3,12 @@ questions:
   - prompt: "Which languages evolved from Latin?"
     options:
       - "German and Dutch"
-      - "Italian, French, Spanish and Romanian"
+      - "Italian"
+      - "French"
+      - "Spanish"
+      - "Romanian"
       - "Chinese and Japanese"
-    answer: 1
+    answer: 1,2,3,4
   - prompt: "Is Latin considered a living language?"
     options:
       - "Yes"


### PR DESCRIPTION
## Summary
- randomize quiz questions and limit to 5
- allow questions to define several valid answers
- switch UI to checkboxes for multi-answer questions
- adjust reset logic and sample quiz data

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6846393c770483328d4f9e49bff51f7e