### PR TITLE
Add matching quiz type

### DIFF
--- a/public/posts/quiz-selvete.md
+++ b/public/posts/quiz-selvete.md
@@ -1,0 +1,10 @@
+---
+questions:
+  - type: match
+    prompt: "Match the English words with the Latin ones"
+    pairs:
+      - ["girl", "puella"]
+      - ["boy", "puer"]
+      - ["book", "liber"]
+      - ["tree", "arbor"]
+---

--- a/src/pages/PostPage.jsx
+++ b/src/pages/PostPage.jsx
@@ -30,10 +30,12 @@ function PostPage() {
   const [answers, setAnswers] = useState([])
   const [submitted, setSubmitted] = useState(false)
   const [tab, setTab] = useState('content')
+  const [activeLeft, setActiveLeft] = useState(null)
 
   const handleAnswer = (qIdx, optionIdx, checked) => {
+    if (!quiz || quiz[qIdx].type === 'match') return
     const updated = [...answers]
-    const isMulti = quiz && Array.isArray(quiz[qIdx].answer) && quiz[qIdx].answer.length > 1
+    const isMulti = Array.isArray(quiz[qIdx].answer) && quiz[qIdx].answer.length > 1
     if (isMulti) {
       const current = new Set(updated[qIdx] || [])
       if (checked) {
@@ -48,6 +50,21 @@ function PostPage() {
     setAnswers(updated)
   }
 
+  const handlePairLeft = (qIdx, li) => {
+    if (submitted) return
+    setActiveLeft({ qIdx, li })
+  }
+
+  const handlePairRight = (qIdx, ri) => {
+    if (submitted || !activeLeft || activeLeft.qIdx !== qIdx) return
+    const updated = [...answers]
+    const mapping = { ...(updated[qIdx] || {}) }
+    mapping[activeLeft.li] = ri
+    updated[qIdx] = mapping
+    setAnswers(updated)
+    setActiveLeft(null)
+  }
+
   const handleDone = () => {
     setSubmitted(true)
   }
@@ -55,12 +72,14 @@ function PostPage() {
   const handleReset = () => {
     if (quiz) {
       setAnswers(
-        quiz.map((q) =>
-          Array.isArray(q.answer) && q.answer.length > 1 ? [] : null
-        )
+        quiz.map((q) => {
+          if (q.type === 'match') return {}
+          return Array.isArray(q.answer) && q.answer.length > 1 ? [] : null
+        })
       )
     }
     setSubmitted(false)
+    setActiveLeft(null)
   }
 
   useEffect(() => {
@@ -106,18 +125,34 @@ function PostPage() {
         const { attributes } = fm(raw)
         if (attributes.questions) {
           const processed = attributes.questions.map((q) => {
+            if (q.type === 'match' && Array.isArray(q.pairs)) {
+              const left = q.pairs.map(p => Array.isArray(p) ? p[0] : p.left)
+              const right = q.pairs.map(p => Array.isArray(p) ? p[1] : p.right)
+              const leftShuffled = [...left].sort(() => Math.random() - 0.5)
+              const rightShuffled = [...right].sort(() => Math.random() - 0.5)
+              const ansMap = {}
+              leftShuffled.forEach((lw, li) => {
+                const origIdx = left.indexOf(lw)
+                const rw = right[origIdx]
+                ansMap[li] = rightShuffled.indexOf(rw)
+              })
+              return { type: 'match', prompt: q.prompt, left: leftShuffled, right: rightShuffled, answer: ansMap }
+            }
             let ans = q.answer
             if (typeof ans === 'string') {
               ans = ans.split(',').map((a) => parseInt(a.trim(), 10)).filter((n) => !isNaN(n))
             } else if (!Array.isArray(ans)) {
               ans = [ans]
             }
-            return { ...q, answer: ans }
+            return { ...q, type: 'multiple', answer: ans }
           })
           // randomize questions and limit to 5
           const shuffled = processed.sort(() => Math.random() - 0.5).slice(0, 5)
           setQuiz(shuffled)
-          setAnswers(shuffled.map((q) => (q.answer.length > 1 ? [] : null)))
+          setAnswers(shuffled.map((q) => {
+            if (q.type === 'match') return {}
+            return q.answer.length > 1 ? [] : null
+          }))
         }
       } catch (err) {
         console.error('Failed to load quiz', err)
@@ -185,49 +220,88 @@ function PostPage() {
 
       {tab === 'quiz' && quiz && (
         <div>
-          {quiz.map((q, qi) => (
-            <div key={qi} className="mb-6">
-              <p className="font-semibold mb-2">{q.prompt}</p>
-              {q.options.map((opt, oi) => (
-                <label key={oi} className="block mb-1">
-                  <input
-                    type={q.answer.length > 1 ? 'checkbox' : 'radio'}
-                    name={`q-${qi}`}
-                    className="mr-2"
-                    onChange={(e) => handleAnswer(qi, oi, e.target.checked)}
-                    checked={
-                      q.answer.length > 1
-                        ? (answers[qi] || []).includes(oi)
-                        : answers[qi] === oi
-                    }
-                    disabled={submitted}
-                  />
-                  {opt}
-                </label>
-              ))}
-              {submitted && (
-                <p
-                  className={`mt-1 font-semibold ${
-                    (q.answer.length > 1
-                      ? q.answer.every((a) => (answers[qi] || []).includes(a)) &&
-                        (answers[qi] || []).length === q.answer.length
-                      : answers[qi] === q.answer[0])
-                      ? 'text-green-600'
-                      : 'text-red-600'
-                  }`}
-                >
-                  {(q.answer.length > 1
-                    ? q.answer.every((a) => (answers[qi] || []).includes(a)) &&
-                      (answers[qi] || []).length === q.answer.length
-                    : answers[qi] === q.answer[0])
-                    ? 'Correct!'
-                    : `Incorrect. Correct answer: ${q.answer
-                        .map((a) => q.options[a])
-                        .join(', ')}`}
-                </p>
-              )}
-            </div>
-          ))}
+          {quiz.map((q, qi) => {
+            const isMatch = q.type === 'match'
+            const isCorrect = submitted && (isMatch
+              ? Object.keys(q.answer).every((k) => (answers[qi] || {})[k] === q.answer[k]) &&
+                Object.keys(answers[qi] || {}).length === Object.keys(q.answer).length
+              : (q.answer.length > 1
+                  ? q.answer.every((a) => (answers[qi] || []).includes(a)) &&
+                    (answers[qi] || []).length === q.answer.length
+                  : answers[qi] === q.answer[0]))
+            return (
+              <div key={qi} className="mb-6">
+                <p className="font-semibold mb-2">{q.prompt}</p>
+                {isMatch ? (
+                  <div className="flex gap-4">
+                    <div className="flex flex-col gap-2">
+                      {q.left.map((word, li) => (
+                        <button
+                          key={li}
+                          onClick={() => handlePairLeft(qi, li)}
+                          disabled={submitted}
+                          className={`px-2 py-1 border rounded ${
+                            activeLeft && activeLeft.qIdx === qi && activeLeft.li === li
+                              ? 'bg-blue-200'
+                              : answers[qi] && answers[qi][li] !== undefined
+                                ? 'bg-green-100'
+                                : ''
+                          }`}
+                        >
+                          {word}
+                        </button>
+                      ))}
+                    </div>
+                    <div className="flex flex-col gap-2">
+                      {q.right.map((word, ri) => (
+                        <button
+                          key={ri}
+                          onClick={() => handlePairRight(qi, ri)}
+                          disabled={submitted}
+                          className={`px-2 py-1 border rounded ${
+                            Object.entries(answers[qi] || {}).some(([l, r]) => r === ri)
+                              ? 'bg-gray-200'
+                              : ''
+                          }`}
+                        >
+                          {word}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                ) : (
+                  q.options.map((opt, oi) => (
+                    <label key={oi} className="block mb-1">
+                      <input
+                        type={q.answer.length > 1 ? 'checkbox' : 'radio'}
+                        name={`q-${qi}`}
+                        className="mr-2"
+                        onChange={(e) => handleAnswer(qi, oi, e.target.checked)}
+                        checked={
+                          q.answer.length > 1
+                            ? (answers[qi] || []).includes(oi)
+                            : answers[qi] === oi
+                        }
+                        disabled={submitted}
+                      />
+                      {opt}
+                    </label>
+                  ))
+                )}
+                {submitted && (
+                  <p className={`mt-1 font-semibold ${isCorrect ? 'text-green-600' : 'text-red-600'}`}>
+                    {isCorrect
+                      ? 'Correct!'
+                      : isMatch
+                        ? 'Incorrect.'
+                        : `Incorrect. Correct answer: ${q.answer
+                            .map((a) => q.options[a])
+                            .join(', ')}`}
+                  </p>
+                )}
+              </div>
+            )
+          })}
 
           {quiz.length > 0 && (
             <div className="mt-4">


### PR DESCRIPTION
## Summary
- introduce matching quiz data format
- support match-type questions in `PostPage`
- add example `quiz-selvete.md`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684670ce00848332a271eeca08bf36c6