### PR TITLE
Limit match questions to 5 pairs

### DIFF
--- a/src/pages/PostPage.jsx
+++ b/src/pages/PostPage.jsx
@@ -126,8 +126,12 @@ function PostPage() {
         if (attributes.questions) {
           const processed = attributes.questions.map((q) => {
             if (q.type === 'match' && Array.isArray(q.pairs)) {
-              const left = q.pairs.map(p => Array.isArray(p) ? p[0] : p.left)
-              const right = q.pairs.map(p => Array.isArray(p) ? p[1] : p.right)
+              let pairs = [...q.pairs]
+              if (pairs.length > 5) {
+                pairs = pairs.sort(() => Math.random() - 0.5).slice(0, 5)
+              }
+              const left = pairs.map(p => Array.isArray(p) ? p[0] : p.left)
+              const right = pairs.map(p => Array.isArray(p) ? p[1] : p.right)
               const leftShuffled = [...left].sort(() => Math.random() - 0.5)
               const rightShuffled = [...right].sort(() => Math.random() - 0.5)
               const ansMap = {}


### PR DESCRIPTION
## Summary
- limit quiz match questions to at most five pairs to avoid overwhelming the user

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6846e66913948332bd7c45f8f5df3e13