### PR TITLE
Build quiz map and load quizzes

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist",
-    "postbuild": "echo > dist/.nojekyll && cp public/posts/posts.json dist/posts/posts.json"
+    "postbuild": "echo > dist/.nojekyll && cp public/posts/posts.json dist/posts/posts.json && cp public/posts/quizes.json dist/posts/quizes.json"
   },
   "dependencies": {
     "buffer": "^6.0.3",


### PR DESCRIPTION
## Summary
- generate a `quizes.json` file during build
- copy quizes.json on postbuild
- load quizzes using quizes.json instead of probing files
- hide Content/Quiz buttons when a post has no quizzes

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684730f5e0348332b3eaf757d8ef36a8