### PR TITLE
Implement sentence building quiz

### DIFF
--- a/public/posts/quiz-3-basics.md
+++ b/public/posts/quiz-3-basics.md
@@ -1,0 +1,15 @@
+---
+questions:
+  - type: sentence
+    prompt: "The girl reads the book"
+    words:
+      - puella
+      - librum
+      - legit
+      - arbor
+      - ascendunt
+    answer:
+      - puella
+      - librum
+      - legit
+---

--- a/public/posts/quizes.json
+++ b/public/posts/quizes.json
@@ -1,0 +1,10 @@
+{
+  "basics.md": [
+    "quiz-1-basics.md",
+    "quiz-2-basics.md",
+    "quiz-3-basics.md"
+  ],
+  "selvete.md": [
+    "quiz-1-selvete.md"
+  ]
+}


### PR DESCRIPTION
## Summary
- implement new quiz type "sentence" that lets users build the Latin phrase by clicking shuffled word tiles
- track selections and disable chosen tiles
- extend quiz parser and rendering logic to support sentence quizzes
- add example quiz `quiz-3-basics.md` and update quiz mapping

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68478100162c8332a4f90c27ef1a2bee