### PR TITLE
Update complete phrase quiz

### DIFF
--- a/public/posts/quiz-1-lectionemunum.md
+++ b/public/posts/quiz-1-lectionemunum.md
@@ -1,7 +1,8 @@
 ---
 questions:
   - type: complete the phrase
-    prompt: Puella nautam MISSING
+    prompt: The girl loves the sailor
+    latin: Puella nautam MISSING
     words:
       - amant
       - amat
@@ -10,7 +11,8 @@ questions:
     answer:
       - amat
   - type: complete the phrase
-    prompt: MISSING insulam amant
+    prompt: The sailors love the island
+    latin: MISSING insulam amant
     words:
       - nautae
       - rex

--- a/src/pages/PostPage.jsx
+++ b/src/pages/PostPage.jsx
@@ -143,7 +143,13 @@ function PostPage() {
               ? q.words
               : [ansWord]
             const shuffledWords = [...allWords].sort(() => Math.random() - 0.5)
-            return { type: 'complete', prompt: q.prompt, words: shuffledWords, answer: ansWord }
+            return {
+              type: 'complete',
+              prompt: q.prompt,
+              latin: q.latin || q.prompt,
+              words: shuffledWords,
+              answer: ansWord,
+            }
           }
           let ans = q.answer
           if (typeof ans === 'string') {
@@ -378,7 +384,7 @@ function PostPage() {
                   </div>
                 ) : isComplete ? (
                   <div>
-                    <p className="mb-2">{q.prompt.replace('MISSING', answers[qi] !== undefined && answers[qi] !== null ? q.words[answers[qi]] : '_____')}</p>
+                    <p className="mb-2">{(q.latin || q.prompt).replace('MISSING', answers[qi] !== undefined && answers[qi] !== null ? q.words[answers[qi]] : '_____')}</p>
                     <div className="flex flex-wrap gap-2">
                       {q.words.map((word, wi) => (
                         <button


### PR DESCRIPTION
## Summary
- add English prompts and store Latin phrase separately in quiz data
- support `latin` field in quiz parser and renderer

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68485a90bd8c833281b1c1011462d9b9