### PR TITLE
Show explanation text for incorrect answers

### DIFF
--- a/src/components/Quiz.jsx
+++ b/src/components/Quiz.jsx
@@ -303,19 +303,24 @@ function Quiz({ sources }) {
               ))
             )}
             {submitted && (
-              <p className={`mt-1 font-semibold ${isCorrect ? 'text-green-600' : 'text-red-600'}`}>
-                {isCorrect
-                  ? 'Correct!'
-                  : isMatch
-                    ? 'Incorrect.'
-                    : isSentence
-                      ? `Incorrect. Correct answer: ${q.answer.join(' ')}`
-                      : isComplete
-                        ? `Incorrect. Correct answer: ${q.answer}`
-                        : `Incorrect. Correct answer: ${q.answer
-                            .map((a) => q.options[a])
-                            .join(', ')}`}
-              </p>
+              <>
+                <p className={`mt-1 font-semibold ${isCorrect ? 'text-green-600' : 'text-red-600'}`}>
+                  {isCorrect
+                    ? 'Correct!'
+                    : isMatch
+                      ? 'Incorrect.'
+                      : isSentence
+                        ? `Incorrect. Correct answer: ${q.answer.join(' ')}`
+                        : isComplete
+                          ? `Incorrect. Correct answer: ${q.answer}`
+                          : `Incorrect. Correct answer: ${q.answer
+                              .map((a) => q.options[a])
+                              .join(', ')}`}
+                </p>
+                {!isCorrect && q.options && q.explanation && (
+                  <p className="mt-1 text-red-600">{q.explanation}</p>
+                )}
+              </>
             )}
           </div>
         )


### PR DESCRIPTION
## Summary
- show an extra explanation block for questions with options if user answered wrong

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6863308999cc833283ccfa58ef1ff26c