### PR TITLE
Add missing word quiz type

### DIFF
--- a/public/posts/lectioi/quiz-missing.md
+++ b/public/posts/lectioi/quiz-missing.md
@@ -1,0 +1,12 @@
+---
+questions:
+  - type: missing
+    prompt: "Puella MISSING forum it"
+    options:
+      - ad
+      - in
+      - sub
+      - cum
+    answer: 0,1
+    explanation: "Both *ad* and *in* can complete the sentence depending on meaning."
+---


### PR DESCRIPTION
## Summary
- implement a new `missing` quiz type
- show immediate feedback when option is clicked
- add sample `quiz-missing.md` with new quiz

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6864553fbc848332890a9fe6c52a7da5