### PR TITLE
Add syntax analysis quiz type

### DIFF
--- a/public/posts/lectioi/quiz-syntax.md
+++ b/public/posts/lectioi/quiz-syntax.md
@@ -1,0 +1,10 @@
+---
+instructions: "Match each part of the sentence with its syntactic function."
+questions:
+  - type: syntax
+    prompt: "Pauci viri veros amicos habent"
+    pairs:
+      - ["Pauci viri", "Subject"]
+      - ["veros amicos", "Object"]
+      - ["habent", "Verb"]
+---


### PR DESCRIPTION
## Summary
- implement new `syntax` quiz type to map sentence parts to functions
- handle state updates and correctness checking for `syntax` questions
- add sample syntax quiz

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686570d365408332aab91a1526432eee