### PR TITLE
Fix explanation output

### DIFF
--- a/src/components/Quiz.jsx
+++ b/src/components/Quiz.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import fm from 'front-matter'
+import Markdown from 'markdown-to-jsx'
 
 function Quiz({ sources }) {
   const [quiz, setQuiz] = useState(null)
@@ -404,7 +405,9 @@ function Quiz({ sources }) {
                   </p>
                 )}
                 {!isCorrect && q.explanation && showNow && (
-                  <p className="mt-1 text-red-600">{q.explanation}</p>
+                  <Markdown className="mt-1 text-red-600" options={{ forceInline: true }}>
+                    {q.explanation}
+                  </Markdown>
                 )}
               </div>
             ) : (
@@ -442,7 +445,9 @@ function Quiz({ sources }) {
                               .join(', ')}`}
                 </p>
                 {!isCorrect && q.explanation && (
-                  <p className="mt-1 text-red-600">{q.explanation}</p>
+                  <Markdown className="mt-1 text-red-600" options={{ forceInline: true }}>
+                    {q.explanation}
+                  </Markdown>
                 )}
               </>
             )}


### PR DESCRIPTION
## Summary
- render quiz explanations using Markdown so they appear when answers are incorrect

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686585c01fd083329bc7eb5d5b4af9a4